### PR TITLE
Expand Post Function(Image)

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,6 +15,6 @@ class PrototypesController < ApplicationController
 
   private
   def prototype_params
-    params.require(:prototype).permit(:title, :catch_copy, :concept)
+    params.require(:prototype).permit(:title, :catch_copy, :concept, image_attributes: [:main_image, :sub_image_1, :sub_image_2, :sub_image_3])
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,2 @@
+class Image < ActiveRecord::Base
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,8 @@
 class Image < ActiveRecord::Base
   belongs_to :prototype
+
+  mount_uploader :main_image, AvatarUploader
+  mount_uploader :sub_image_1, AvatarUploader
+  mount_uploader :sub_image_2, AvatarUploader
+  mount_uploader :sub_image_3, AvatarUploader
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,3 @@
 class Image < ActiveRecord::Base
+  belongs_to :prototype
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,3 +1,6 @@
 class Prototype < ActiveRecord::Base
+  has_one :image
+  accepts_nested_attributes_for :image
+
   validates :title, :catch_copy, :concept, presence: true
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,3 +10,5 @@
     = render "layouts/header"
     = yield
     = render "layouts/footer"
+    %script{src: "/assets/protospace.js"}
+

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -8,20 +8,21 @@
             = flash[:notice]
         = f.text_field :title, autofocus: true, placeholder: "Title"
       .row
-        .col-md-12
-          .cover-image-upload
-            %input{type: "file"}/
-        .col-md-12
-          %ul.proto-sub-list.list-group
-            %li.list-group-item.col-md-4
-              .image-upload
-                %input{type: "file"}/
-            %li.list-group-item.col-md-4
-              .image-upload
-                %input{type: "file"}/
-            %li.list-group-item.col-md-4
-              .image-upload-plus
-                %span +
+        = f.fields_for :image, @prototype.image || Image.new do |i|
+          .col-md-12
+            .cover-image-upload
+              = i.file_field :main_image
+          .col-md-12
+            %ul.proto-sub-list.list-group
+              %li.list-group-item.col-md-4
+                .image-upload
+                  = i.file_field :sub_image_1
+              %li.list-group-item.col-md-4
+                .image-upload
+                  = i.file_field :sub_image_2
+              %li.list-group-item.col-md-4
+                .image-upload-plus
+                  %span +
       .row.proto-description
         .col-md-12
           = f.text_field :catch_copy, placeholder: "Catch copy"
@@ -42,4 +43,3 @@
         /     .col-md-3
         /       = f.text_field :application, placeholder: "Application"
       
-

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -24,6 +24,6 @@
             .user-name_image.row
               .user-name.col-md-12
                 = f.text_area :works, cols: "30", rows: "4"
-            .actions.btn.btn-lg.btn-primary.btn-block
-              = f.submit "Save"
+            %button.actions.btn.btn-lg.btn-primary.btn-block
+              Save
       

--- a/db/migrate/20150721145746_create_images.rb
+++ b/db/migrate/20150721145746_create_images.rb
@@ -1,0 +1,12 @@
+class CreateImages < ActiveRecord::Migration
+  def change
+    create_table :images do |t|
+      t.string :main_image, null: false
+      t.string :sub_image_1
+      t.string :sub_image_2
+      t.string :sub_image_3
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150722033830_add_prototype_id_to_images.rb
+++ b/db/migrate/20150722033830_add_prototype_id_to_images.rb
@@ -1,0 +1,5 @@
+class AddPrototypeIdToImages < ActiveRecord::Migration
+  def change
+    add_column :images, :prototype_id, :integer, after: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150721145746) do
+ActiveRecord::Schema.define(version: 20150722033830) do
 
   create_table "images", force: :cascade do |t|
-    t.string   "main_image",  limit: 255, null: false
-    t.string   "sub_image_1", limit: 255
-    t.string   "sub_image_2", limit: 255
-    t.string   "sub_image_3", limit: 255
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "prototype_id", limit: 4
+    t.string   "main_image",   limit: 255, null: false
+    t.string   "sub_image_1",  limit: 255
+    t.string   "sub_image_2",  limit: 255
+    t.string   "sub_image_3",  limit: 255
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   create_table "prototypes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150720094010) do
+ActiveRecord::Schema.define(version: 20150721145746) do
+
+  create_table "images", force: :cascade do |t|
+    t.string   "main_image",  limit: 255, null: false
+    t.string   "sub_image_1", limit: 255
+    t.string   "sub_image_2", limit: 255
+    t.string   "sub_image_3", limit: 255
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
 
   create_table "prototypes", force: :cascade do |t|
     t.string   "title",      limit: 255,   default: "", null: false


### PR DESCRIPTION
## ??

Expand post function to it could save images
画像が保存できるように投稿機能を拡張
## !?

images is the biggest information of prototype what user going to make
画像が一番わかりやすく重要な情報だから
## How

実装方法について
First, I planed to store images data with serialize. During I work to this project, however, I started to think that create the images table and force stroe all images data to one record is more effective approach.

はじめはシリアライズを用いて実装する予定だったが、冷静に考えてアソシエーションを定義して、一つのプロトタイプに一つの画像をひもづけた方が自然に思えたので、そうすることにする。
この辺についてより良いデザインがある場合教えていただきたいです。
（今考えてみると、一つのプロトタイプに一つの画像のレコード（レコードには４つの画像のurlを格納するカラムがある）なのに、アソシエーションでひもづけるのはどうなのか？と思えてきました。だったら、画像を投稿する際一つのレコードにまとめずに、わざわざ』４つのレコードが保存されるようにするべきなのでしょうか？　でもかっこわるいですよね、いたずらにレコードを増やす結果になりますし・・・一つのレコードでとってきてその後処理出来た方が、SQL発行回数的にも美しいんじゃないか　　　とりあえず考えたもので試行錯誤していきます。）
